### PR TITLE
Added right crowfoot notation '--{' to parser, incl test

### DIFF
--- a/src/plantuml.pegjs
+++ b/src/plantuml.pegjs
@@ -447,6 +447,7 @@ RelationshipArrowHead
   / "#"
   / "x"
   / "}"
+  / "{"
   / "+"
   / "^"
   / "()"

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,7 @@ export type RelationshipArrowHead = (
   | '#'
   | 'x'
   | '}'
+  | '{'
   | '+'
   | '^'
   | '()'

--- a/test/fixtures/class-relationships-crowfeet/in.plantuml
+++ b/test/fixtures/class-relationships-crowfeet/in.plantuml
@@ -1,0 +1,22 @@
+@startuml
+
+title Relationships - Class Diagram with Crowfeet
+
+class Dwelling {
+  +Int Windows
+  +void LockTheDoor()
+}
+
+class Apartment
+class House
+class Commune
+class Window
+class Door
+
+Dwelling <|-down- Apartment: Inheritance
+Dwelling <|-down- Commune: Inheritance
+Dwelling <|-down- House: Inheritance
+Window }-- Dwelling: Composition
+Dwelling --{ Door: Composition
+
+@enduml

--- a/test/fixtures/class-relationships-crowfeet/in.plantuml
+++ b/test/fixtures/class-relationships-crowfeet/in.plantuml
@@ -2,21 +2,10 @@
 
 title Relationships - Class Diagram with Crowfeet
 
-class Dwelling {
-  +Int Windows
-  +void LockTheDoor()
-}
+class A
+class B
 
-class Apartment
-class House
-class Commune
-class Window
-class Door
-
-Dwelling <|-down- Apartment: Inheritance
-Dwelling <|-down- Commune: Inheritance
-Dwelling <|-down- House: Inheritance
-Window }-- Dwelling: Composition
-Dwelling --{ Door: Composition
+A }-- B: Crowfeet left
+A --{ B: Crowfeet right
 
 @enduml

--- a/test/fixtures/class-relationships-crowfeet/parse-out.default
+++ b/test/fixtures/class-relationships-crowfeet/parse-out.default
@@ -1,0 +1,126 @@
+[
+  {
+    "elements": [
+      {
+        "name": "Dwelling",
+        "title": "Dwelling",
+        "isAbstract": false,
+        "members": [
+          {
+            "name": "Windows",
+            "isStatic": false,
+            "accessor": "+",
+            "type": "Int"
+          },
+          {
+            "name": "LockTheDoor",
+            "isStatic": false,
+            "accessor": "+",
+            "returnType": "void",
+            "_arguments": ""
+          }
+        ]
+      },
+      {
+        "name": "Apartment",
+        "title": "Apartment",
+        "isAbstract": false,
+        "members": []
+      },
+      {
+        "name": "House",
+        "title": "House",
+        "isAbstract": false,
+        "members": []
+      },
+      {
+        "name": "Commune",
+        "title": "Commune",
+        "isAbstract": false,
+        "members": []
+      },
+      {
+        "name": "Window",
+        "title": "Window",
+        "isAbstract": false,
+        "members": []
+      },
+      {
+        "name": "Door",
+        "title": "Door",
+        "isAbstract": false,
+        "members": []
+      },
+      {
+        "left": "Dwelling",
+        "right": "Apartment",
+        "leftType": "Unknown",
+        "rightType": "Unknown",
+        "leftArrowHead": "<|",
+        "rightArrowHead": "",
+        "leftArrowBody": "-",
+        "rightArrowBody": "-",
+        "leftCardinality": "",
+        "rightCardinality": "",
+        "label": "Inheritance",
+        "hidden": false
+      },
+      {
+        "left": "Dwelling",
+        "right": "Commune",
+        "leftType": "Unknown",
+        "rightType": "Unknown",
+        "leftArrowHead": "<|",
+        "rightArrowHead": "",
+        "leftArrowBody": "-",
+        "rightArrowBody": "-",
+        "leftCardinality": "",
+        "rightCardinality": "",
+        "label": "Inheritance",
+        "hidden": false
+      },
+      {
+        "left": "Dwelling",
+        "right": "House",
+        "leftType": "Unknown",
+        "rightType": "Unknown",
+        "leftArrowHead": "<|",
+        "rightArrowHead": "",
+        "leftArrowBody": "-",
+        "rightArrowBody": "-",
+        "leftCardinality": "",
+        "rightCardinality": "",
+        "label": "Inheritance",
+        "hidden": false
+      },
+      {
+        "left": "Window",
+        "right": "Dwelling",
+        "leftType": "Unknown",
+        "rightType": "Unknown",
+        "leftArrowHead": "}",
+        "rightArrowHead": "",
+        "leftArrowBody": "-",
+        "rightArrowBody": "-",
+        "leftCardinality": "",
+        "rightCardinality": "",
+        "label": "Composition",
+        "hidden": false
+      },
+      {
+        "left": "Dwelling",
+        "right": "Door",
+        "leftType": "Unknown",
+        "rightType": "Unknown",
+        "leftArrowHead": "",
+        "rightArrowHead": "{",
+        "leftArrowBody": "-",
+        "rightArrowBody": "-",
+        "leftCardinality": "",
+        "rightCardinality": "",
+        "label": "Composition",
+        "hidden": false
+      }
+    ]
+  }
+]

--- a/test/fixtures/class-relationships-crowfeet/parse-out.default
+++ b/test/fixtures/class-relationships-crowfeet/parse-out.default
@@ -2,100 +2,20 @@
   {
     "elements": [
       {
-        "name": "Dwelling",
-        "title": "Dwelling",
-        "isAbstract": false,
-        "members": [
-          {
-            "name": "Windows",
-            "isStatic": false,
-            "accessor": "+",
-            "type": "Int"
-          },
-          {
-            "name": "LockTheDoor",
-            "isStatic": false,
-            "accessor": "+",
-            "returnType": "void",
-            "_arguments": ""
-          }
-        ]
-      },
-      {
-        "name": "Apartment",
-        "title": "Apartment",
+        "name": "A",
+        "title": "A",
         "isAbstract": false,
         "members": []
       },
       {
-        "name": "House",
-        "title": "House",
+        "name": "B",
+        "title": "B",
         "isAbstract": false,
         "members": []
       },
       {
-        "name": "Commune",
-        "title": "Commune",
-        "isAbstract": false,
-        "members": []
-      },
-      {
-        "name": "Window",
-        "title": "Window",
-        "isAbstract": false,
-        "members": []
-      },
-      {
-        "name": "Door",
-        "title": "Door",
-        "isAbstract": false,
-        "members": []
-      },
-      {
-        "left": "Dwelling",
-        "right": "Apartment",
-        "leftType": "Unknown",
-        "rightType": "Unknown",
-        "leftArrowHead": "<|",
-        "rightArrowHead": "",
-        "leftArrowBody": "-",
-        "rightArrowBody": "-",
-        "leftCardinality": "",
-        "rightCardinality": "",
-        "label": "Inheritance",
-        "hidden": false
-      },
-      {
-        "left": "Dwelling",
-        "right": "Commune",
-        "leftType": "Unknown",
-        "rightType": "Unknown",
-        "leftArrowHead": "<|",
-        "rightArrowHead": "",
-        "leftArrowBody": "-",
-        "rightArrowBody": "-",
-        "leftCardinality": "",
-        "rightCardinality": "",
-        "label": "Inheritance",
-        "hidden": false
-      },
-      {
-        "left": "Dwelling",
-        "right": "House",
-        "leftType": "Unknown",
-        "rightType": "Unknown",
-        "leftArrowHead": "<|",
-        "rightArrowHead": "",
-        "leftArrowBody": "-",
-        "rightArrowBody": "-",
-        "leftCardinality": "",
-        "rightCardinality": "",
-        "label": "Inheritance",
-        "hidden": false
-      },
-      {
-        "left": "Window",
-        "right": "Dwelling",
+        "left": "A",
+        "right": "B",
         "leftType": "Unknown",
         "rightType": "Unknown",
         "leftArrowHead": "}",
@@ -104,12 +24,12 @@
         "rightArrowBody": "-",
         "leftCardinality": "",
         "rightCardinality": "",
-        "label": "Composition",
+        "label": "Crowfeet left",
         "hidden": false
       },
       {
-        "left": "Dwelling",
-        "right": "Door",
+        "left": "A",
+        "right": "B",
         "leftType": "Unknown",
         "rightType": "Unknown",
         "leftArrowHead": "",
@@ -118,7 +38,7 @@
         "rightArrowBody": "-",
         "leftCardinality": "",
         "rightCardinality": "",
-        "label": "Composition",
+        "label": "Crowfeet right",
         "hidden": false
       }
     ]

--- a/test/fixtures/class-relationships-crowfeet/parse-out.graph
+++ b/test/fixtures/class-relationships-crowfeet/parse-out.graph
@@ -1,0 +1,106 @@
+{
+  "nodes": [
+    {
+      "name": "Dwelling",
+      "title": "Dwelling",
+      "isAbstract": false,
+      "members": [
+        {
+          "name": "Windows",
+          "isStatic": false,
+          "accessor": "+",
+          "type": "Int"
+        },
+        {
+          "name": "LockTheDoor",
+          "isStatic": false,
+          "accessor": "+",
+          "returnType": "void",
+          "_arguments": ""
+        }
+      ],
+      "id": "Dwelling",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "Windows",
+      "isStatic": false,
+      "accessor": "+",
+      "type": "Attribute",
+      "id": "Windows",
+      "hidden": true
+    },
+    {
+      "name": "Apartment",
+      "title": "Apartment",
+      "isAbstract": false,
+      "members": [],
+      "id": "Apartment",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "House",
+      "title": "House",
+      "isAbstract": false,
+      "members": [],
+      "id": "House",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "Commune",
+      "title": "Commune",
+      "isAbstract": false,
+      "members": [],
+      "id": "Commune",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "Window",
+      "title": "Window",
+      "isAbstract": false,
+      "members": [],
+      "id": "Window",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "Door",
+      "title": "Door",
+      "isAbstract": false,
+      "members": [],
+      "id": "Door",
+      "type": "Class",
+      "hidden": true
+    }
+  ],
+  "edges": [
+    {
+      "from": "Dwelling",
+      "to": "Windows",
+      "name": "has",
+      "hidden": true
+    },
+    {
+      "from": "Apartment",
+      "to": "Dwelling",
+      "name": "extends",
+      "hidden": true
+    },
+    {
+      "from": "Commune",
+      "to": "Dwelling",
+      "name": "extends",
+      "hidden": true
+    },
+    {
+      "from": "House",
+      "to": "Dwelling",
+      "name": "extends",
+      "hidden": true
+    }
+  ]
+}

--- a/test/fixtures/class-relationships-crowfeet/parse-out.graph
+++ b/test/fixtures/class-relationships-crowfeet/parse-out.graph
@@ -1,106 +1,23 @@
 {
   "nodes": [
     {
-      "name": "Dwelling",
-      "title": "Dwelling",
+      "name": "A",
+      "title": "A",
       "isAbstract": false,
-      "members": [
-        {
-          "name": "Windows",
-          "isStatic": false,
-          "accessor": "+",
-          "type": "Int"
-        },
-        {
-          "name": "LockTheDoor",
-          "isStatic": false,
-          "accessor": "+",
-          "returnType": "void",
-          "_arguments": ""
-        }
-      ],
-      "id": "Dwelling",
+      "members": [],
+      "id": "A",
       "type": "Class",
       "hidden": true
     },
     {
-      "name": "Windows",
-      "isStatic": false,
-      "accessor": "+",
-      "type": "Attribute",
-      "id": "Windows",
-      "hidden": true
-    },
-    {
-      "name": "Apartment",
-      "title": "Apartment",
+      "name": "B",
+      "title": "B",
       "isAbstract": false,
       "members": [],
-      "id": "Apartment",
-      "type": "Class",
-      "hidden": true
-    },
-    {
-      "name": "House",
-      "title": "House",
-      "isAbstract": false,
-      "members": [],
-      "id": "House",
-      "type": "Class",
-      "hidden": true
-    },
-    {
-      "name": "Commune",
-      "title": "Commune",
-      "isAbstract": false,
-      "members": [],
-      "id": "Commune",
-      "type": "Class",
-      "hidden": true
-    },
-    {
-      "name": "Window",
-      "title": "Window",
-      "isAbstract": false,
-      "members": [],
-      "id": "Window",
-      "type": "Class",
-      "hidden": true
-    },
-    {
-      "name": "Door",
-      "title": "Door",
-      "isAbstract": false,
-      "members": [],
-      "id": "Door",
+      "id": "B",
       "type": "Class",
       "hidden": true
     }
   ],
-  "edges": [
-    {
-      "from": "Dwelling",
-      "to": "Windows",
-      "name": "has",
-      "hidden": true
-    },
-    {
-      "from": "Apartment",
-      "to": "Dwelling",
-      "name": "extends",
-      "hidden": true
-    },
-    {
-      "from": "Commune",
-      "to": "Dwelling",
-      "name": "extends",
-      "hidden": true
-    },
-    {
-      "from": "House",
-      "to": "Dwelling",
-      "name": "extends",
-      "hidden": true
-    }
-  ]
+  "edges": []
 }

--- a/test/fixtures/class-relationships-crowfeet/parseFile-out.default
+++ b/test/fixtures/class-relationships-crowfeet/parseFile-out.default
@@ -1,0 +1,131 @@
+[
+  {
+    "name": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+    "diagrams": [
+      {
+        "elements": [
+          {
+            "name": "Dwelling",
+            "title": "Dwelling",
+            "isAbstract": false,
+            "members": [
+              {
+                "name": "Windows",
+                "isStatic": false,
+                "accessor": "+",
+                "type": "Int"
+              },
+              {
+                "name": "LockTheDoor",
+                "isStatic": false,
+                "accessor": "+",
+                "returnType": "void",
+                "_arguments": ""
+              }
+            ]
+          },
+          {
+            "name": "Apartment",
+            "title": "Apartment",
+            "isAbstract": false,
+            "members": []
+          },
+          {
+            "name": "House",
+            "title": "House",
+            "isAbstract": false,
+            "members": []
+          },
+          {
+            "name": "Commune",
+            "title": "Commune",
+            "isAbstract": false,
+            "members": []
+          },
+          {
+            "name": "Window",
+            "title": "Window",
+            "isAbstract": false,
+            "members": []
+          },
+          {
+            "name": "Door",
+            "title": "Door",
+            "isAbstract": false,
+            "members": []
+          },
+          {
+            "left": "Dwelling",
+            "right": "Apartment",
+            "leftType": "Unknown",
+            "rightType": "Unknown",
+            "leftArrowHead": "<|",
+            "rightArrowHead": "",
+            "leftArrowBody": "-",
+            "rightArrowBody": "-",
+            "leftCardinality": "",
+            "rightCardinality": "",
+            "label": "Inheritance",
+            "hidden": false
+          },
+          {
+            "left": "Dwelling",
+            "right": "Commune",
+            "leftType": "Unknown",
+            "rightType": "Unknown",
+            "leftArrowHead": "<|",
+            "rightArrowHead": "",
+            "leftArrowBody": "-",
+            "rightArrowBody": "-",
+            "leftCardinality": "",
+            "rightCardinality": "",
+            "label": "Inheritance",
+            "hidden": false
+          },
+          {
+            "left": "Dwelling",
+            "right": "House",
+            "leftType": "Unknown",
+            "rightType": "Unknown",
+            "leftArrowHead": "<|",
+            "rightArrowHead": "",
+            "leftArrowBody": "-",
+            "rightArrowBody": "-",
+            "leftCardinality": "",
+            "rightCardinality": "",
+            "label": "Inheritance",
+            "hidden": false
+          },
+          {
+            "left": "Window",
+            "right": "Dwelling",
+            "leftType": "Unknown",
+            "rightType": "Unknown",
+            "leftArrowHead": "}",
+            "rightArrowHead": "",
+            "leftArrowBody": "-",
+            "rightArrowBody": "-",
+            "leftCardinality": "",
+            "rightCardinality": "",
+            "label": "Composition",
+            "hidden": false
+          },
+          {
+            "left": "Dwelling",
+            "right": "Door",
+            "leftType": "Unknown",
+            "rightType": "Unknown",
+            "leftArrowHead": "",
+            "rightArrowHead": "{",
+            "leftArrowBody": "-",
+            "rightArrowBody": "-",
+            "leftCardinality": "",
+            "rightCardinality": "",
+            "label": "Composition",
+            "hidden": false
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/fixtures/class-relationships-crowfeet/parseFile-out.default
+++ b/test/fixtures/class-relationships-crowfeet/parseFile-out.default
@@ -5,100 +5,20 @@
       {
         "elements": [
           {
-            "name": "Dwelling",
-            "title": "Dwelling",
-            "isAbstract": false,
-            "members": [
-              {
-                "name": "Windows",
-                "isStatic": false,
-                "accessor": "+",
-                "type": "Int"
-              },
-              {
-                "name": "LockTheDoor",
-                "isStatic": false,
-                "accessor": "+",
-                "returnType": "void",
-                "_arguments": ""
-              }
-            ]
-          },
-          {
-            "name": "Apartment",
-            "title": "Apartment",
+            "name": "A",
+            "title": "A",
             "isAbstract": false,
             "members": []
           },
           {
-            "name": "House",
-            "title": "House",
+            "name": "B",
+            "title": "B",
             "isAbstract": false,
             "members": []
           },
           {
-            "name": "Commune",
-            "title": "Commune",
-            "isAbstract": false,
-            "members": []
-          },
-          {
-            "name": "Window",
-            "title": "Window",
-            "isAbstract": false,
-            "members": []
-          },
-          {
-            "name": "Door",
-            "title": "Door",
-            "isAbstract": false,
-            "members": []
-          },
-          {
-            "left": "Dwelling",
-            "right": "Apartment",
-            "leftType": "Unknown",
-            "rightType": "Unknown",
-            "leftArrowHead": "<|",
-            "rightArrowHead": "",
-            "leftArrowBody": "-",
-            "rightArrowBody": "-",
-            "leftCardinality": "",
-            "rightCardinality": "",
-            "label": "Inheritance",
-            "hidden": false
-          },
-          {
-            "left": "Dwelling",
-            "right": "Commune",
-            "leftType": "Unknown",
-            "rightType": "Unknown",
-            "leftArrowHead": "<|",
-            "rightArrowHead": "",
-            "leftArrowBody": "-",
-            "rightArrowBody": "-",
-            "leftCardinality": "",
-            "rightCardinality": "",
-            "label": "Inheritance",
-            "hidden": false
-          },
-          {
-            "left": "Dwelling",
-            "right": "House",
-            "leftType": "Unknown",
-            "rightType": "Unknown",
-            "leftArrowHead": "<|",
-            "rightArrowHead": "",
-            "leftArrowBody": "-",
-            "rightArrowBody": "-",
-            "leftCardinality": "",
-            "rightCardinality": "",
-            "label": "Inheritance",
-            "hidden": false
-          },
-          {
-            "left": "Window",
-            "right": "Dwelling",
+            "left": "A",
+            "right": "B",
             "leftType": "Unknown",
             "rightType": "Unknown",
             "leftArrowHead": "}",
@@ -107,12 +27,12 @@
             "rightArrowBody": "-",
             "leftCardinality": "",
             "rightCardinality": "",
-            "label": "Composition",
+            "label": "Crowfeet left",
             "hidden": false
           },
           {
-            "left": "Dwelling",
-            "right": "Door",
+            "left": "A",
+            "right": "B",
             "leftType": "Unknown",
             "rightType": "Unknown",
             "leftArrowHead": "",
@@ -121,7 +41,7 @@
             "rightArrowBody": "-",
             "leftCardinality": "",
             "rightCardinality": "",
-            "label": "Composition",
+            "label": "Crowfeet right",
             "hidden": false
           }
         ]

--- a/test/fixtures/class-relationships-crowfeet/parseFile-out.graph
+++ b/test/fixtures/class-relationships-crowfeet/parseFile-out.graph
@@ -1,0 +1,280 @@
+{
+  "nodes": [
+    {
+      "name": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+      "diagrams": [
+        {
+          "elements": [
+            {
+              "name": "Dwelling",
+              "title": "Dwelling",
+              "isAbstract": false,
+              "members": [
+                {
+                  "name": "Windows",
+                  "isStatic": false,
+                  "accessor": "+",
+                  "type": "Int"
+                },
+                {
+                  "name": "LockTheDoor",
+                  "isStatic": false,
+                  "accessor": "+",
+                  "returnType": "void",
+                  "_arguments": ""
+                }
+              ]
+            },
+            {
+              "name": "Apartment",
+              "title": "Apartment",
+              "isAbstract": false,
+              "members": []
+            },
+            {
+              "name": "House",
+              "title": "House",
+              "isAbstract": false,
+              "members": []
+            },
+            {
+              "name": "Commune",
+              "title": "Commune",
+              "isAbstract": false,
+              "members": []
+            },
+            {
+              "name": "Window",
+              "title": "Window",
+              "isAbstract": false,
+              "members": []
+            },
+            {
+              "name": "Door",
+              "title": "Door",
+              "isAbstract": false,
+              "members": []
+            },
+            {
+              "left": "Dwelling",
+              "right": "Apartment",
+              "leftType": "Unknown",
+              "rightType": "Unknown",
+              "leftArrowHead": "<|",
+              "rightArrowHead": "",
+              "leftArrowBody": "-",
+              "rightArrowBody": "-",
+              "leftCardinality": "",
+              "rightCardinality": "",
+              "label": "Inheritance",
+              "hidden": false
+            },
+            {
+              "left": "Dwelling",
+              "right": "Commune",
+              "leftType": "Unknown",
+              "rightType": "Unknown",
+              "leftArrowHead": "<|",
+              "rightArrowHead": "",
+              "leftArrowBody": "-",
+              "rightArrowBody": "-",
+              "leftCardinality": "",
+              "rightCardinality": "",
+              "label": "Inheritance",
+              "hidden": false
+            },
+            {
+              "left": "Dwelling",
+              "right": "House",
+              "leftType": "Unknown",
+              "rightType": "Unknown",
+              "leftArrowHead": "<|",
+              "rightArrowHead": "",
+              "leftArrowBody": "-",
+              "rightArrowBody": "-",
+              "leftCardinality": "",
+              "rightCardinality": "",
+              "label": "Inheritance",
+              "hidden": false
+            },
+            {
+              "left": "Window",
+              "right": "Dwelling",
+              "leftType": "Unknown",
+              "rightType": "Unknown",
+              "leftArrowHead": "}",
+              "rightArrowHead": "",
+              "leftArrowBody": "-",
+              "rightArrowBody": "-",
+              "leftCardinality": "",
+              "rightCardinality": "",
+              "label": "Composition",
+              "hidden": false
+            },
+            {
+              "left": "Dwelling",
+              "right": "Door",
+              "leftType": "Unknown",
+              "rightType": "Unknown",
+              "leftArrowHead": "",
+              "rightArrowHead": "{",
+              "leftArrowBody": "-",
+              "rightArrowBody": "-",
+              "leftCardinality": "",
+              "rightCardinality": "",
+              "label": "Composition",
+              "hidden": false
+            }
+          ]
+        }
+      ],
+      "id": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+      "type": "File",
+      "hidden": true
+    },
+    {
+      "name": "Dwelling",
+      "title": "Dwelling",
+      "isAbstract": false,
+      "members": [
+        {
+          "name": "Windows",
+          "isStatic": false,
+          "accessor": "+",
+          "type": "Int"
+        },
+        {
+          "name": "LockTheDoor",
+          "isStatic": false,
+          "accessor": "+",
+          "returnType": "void",
+          "_arguments": ""
+        }
+      ],
+      "id": "Dwelling",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "Windows",
+      "isStatic": false,
+      "accessor": "+",
+      "type": "Attribute",
+      "id": "Windows",
+      "hidden": true
+    },
+    {
+      "name": "Apartment",
+      "title": "Apartment",
+      "isAbstract": false,
+      "members": [],
+      "id": "Apartment",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "House",
+      "title": "House",
+      "isAbstract": false,
+      "members": [],
+      "id": "House",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "Commune",
+      "title": "Commune",
+      "isAbstract": false,
+      "members": [],
+      "id": "Commune",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "Window",
+      "title": "Window",
+      "isAbstract": false,
+      "members": [],
+      "id": "Window",
+      "type": "Class",
+      "hidden": true
+    },
+    {
+      "name": "Door",
+      "title": "Door",
+      "isAbstract": false,
+      "members": [],
+      "id": "Door",
+      "type": "Class",
+      "hidden": true
+    }
+  ],
+  "edges": [
+    {
+      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+      "to": "Dwelling",
+      "name": "contains",
+      "hidden": true
+    },
+    {
+      "from": "Dwelling",
+      "to": "Windows",
+      "name": "has",
+      "hidden": true
+    },
+    {
+      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+      "to": "Windows",
+      "name": "contains",
+      "hidden": true
+    },
+    {
+      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+      "to": "Apartment",
+      "name": "contains",
+      "hidden": true
+    },
+    {
+      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+      "to": "House",
+      "name": "contains",
+      "hidden": true
+    },
+    {
+      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+      "to": "Commune",
+      "name": "contains",
+      "hidden": true
+    },
+    {
+      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+      "to": "Window",
+      "name": "contains",
+      "hidden": true
+    },
+    {
+      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
+      "to": "Door",
+      "name": "contains",
+      "hidden": true
+    },
+    {
+      "from": "Apartment",
+      "to": "Dwelling",
+      "name": "extends",
+      "hidden": true
+    },
+    {
+      "from": "Commune",
+      "to": "Dwelling",
+      "name": "extends",
+      "hidden": true
+    },
+    {
+      "from": "House",
+      "to": "Dwelling",
+      "name": "extends",
+      "hidden": true
+    }
+  ]
+}

--- a/test/fixtures/class-relationships-crowfeet/parseFile-out.graph
+++ b/test/fixtures/class-relationships-crowfeet/parseFile-out.graph
@@ -6,100 +6,20 @@
         {
           "elements": [
             {
-              "name": "Dwelling",
-              "title": "Dwelling",
-              "isAbstract": false,
-              "members": [
-                {
-                  "name": "Windows",
-                  "isStatic": false,
-                  "accessor": "+",
-                  "type": "Int"
-                },
-                {
-                  "name": "LockTheDoor",
-                  "isStatic": false,
-                  "accessor": "+",
-                  "returnType": "void",
-                  "_arguments": ""
-                }
-              ]
-            },
-            {
-              "name": "Apartment",
-              "title": "Apartment",
+              "name": "A",
+              "title": "A",
               "isAbstract": false,
               "members": []
             },
             {
-              "name": "House",
-              "title": "House",
+              "name": "B",
+              "title": "B",
               "isAbstract": false,
               "members": []
             },
             {
-              "name": "Commune",
-              "title": "Commune",
-              "isAbstract": false,
-              "members": []
-            },
-            {
-              "name": "Window",
-              "title": "Window",
-              "isAbstract": false,
-              "members": []
-            },
-            {
-              "name": "Door",
-              "title": "Door",
-              "isAbstract": false,
-              "members": []
-            },
-            {
-              "left": "Dwelling",
-              "right": "Apartment",
-              "leftType": "Unknown",
-              "rightType": "Unknown",
-              "leftArrowHead": "<|",
-              "rightArrowHead": "",
-              "leftArrowBody": "-",
-              "rightArrowBody": "-",
-              "leftCardinality": "",
-              "rightCardinality": "",
-              "label": "Inheritance",
-              "hidden": false
-            },
-            {
-              "left": "Dwelling",
-              "right": "Commune",
-              "leftType": "Unknown",
-              "rightType": "Unknown",
-              "leftArrowHead": "<|",
-              "rightArrowHead": "",
-              "leftArrowBody": "-",
-              "rightArrowBody": "-",
-              "leftCardinality": "",
-              "rightCardinality": "",
-              "label": "Inheritance",
-              "hidden": false
-            },
-            {
-              "left": "Dwelling",
-              "right": "House",
-              "leftType": "Unknown",
-              "rightType": "Unknown",
-              "leftArrowHead": "<|",
-              "rightArrowHead": "",
-              "leftArrowBody": "-",
-              "rightArrowBody": "-",
-              "leftCardinality": "",
-              "rightCardinality": "",
-              "label": "Inheritance",
-              "hidden": false
-            },
-            {
-              "left": "Window",
-              "right": "Dwelling",
+              "left": "A",
+              "right": "B",
               "leftType": "Unknown",
               "rightType": "Unknown",
               "leftArrowHead": "}",
@@ -108,12 +28,12 @@
               "rightArrowBody": "-",
               "leftCardinality": "",
               "rightCardinality": "",
-              "label": "Composition",
+              "label": "Crowfeet left",
               "hidden": false
             },
             {
-              "left": "Dwelling",
-              "right": "Door",
+              "left": "A",
+              "right": "B",
               "leftType": "Unknown",
               "rightType": "Unknown",
               "leftArrowHead": "",
@@ -122,7 +42,7 @@
               "rightArrowBody": "-",
               "leftCardinality": "",
               "rightCardinality": "",
-              "label": "Composition",
+              "label": "Crowfeet right",
               "hidden": false
             }
           ]
@@ -133,78 +53,20 @@
       "hidden": true
     },
     {
-      "name": "Dwelling",
-      "title": "Dwelling",
+      "name": "A",
+      "title": "A",
       "isAbstract": false,
-      "members": [
-        {
-          "name": "Windows",
-          "isStatic": false,
-          "accessor": "+",
-          "type": "Int"
-        },
-        {
-          "name": "LockTheDoor",
-          "isStatic": false,
-          "accessor": "+",
-          "returnType": "void",
-          "_arguments": ""
-        }
-      ],
-      "id": "Dwelling",
+      "members": [],
+      "id": "A",
       "type": "Class",
       "hidden": true
     },
     {
-      "name": "Windows",
-      "isStatic": false,
-      "accessor": "+",
-      "type": "Attribute",
-      "id": "Windows",
-      "hidden": true
-    },
-    {
-      "name": "Apartment",
-      "title": "Apartment",
+      "name": "B",
+      "title": "B",
       "isAbstract": false,
       "members": [],
-      "id": "Apartment",
-      "type": "Class",
-      "hidden": true
-    },
-    {
-      "name": "House",
-      "title": "House",
-      "isAbstract": false,
-      "members": [],
-      "id": "House",
-      "type": "Class",
-      "hidden": true
-    },
-    {
-      "name": "Commune",
-      "title": "Commune",
-      "isAbstract": false,
-      "members": [],
-      "id": "Commune",
-      "type": "Class",
-      "hidden": true
-    },
-    {
-      "name": "Window",
-      "title": "Window",
-      "isAbstract": false,
-      "members": [],
-      "id": "Window",
-      "type": "Class",
-      "hidden": true
-    },
-    {
-      "name": "Door",
-      "title": "Door",
-      "isAbstract": false,
-      "members": [],
-      "id": "Door",
+      "id": "B",
       "type": "Class",
       "hidden": true
     }
@@ -212,68 +74,14 @@
   "edges": [
     {
       "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
-      "to": "Dwelling",
-      "name": "contains",
-      "hidden": true
-    },
-    {
-      "from": "Dwelling",
-      "to": "Windows",
-      "name": "has",
-      "hidden": true
-    },
-    {
-      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
-      "to": "Windows",
+      "to": "A",
       "name": "contains",
       "hidden": true
     },
     {
       "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
-      "to": "Apartment",
+      "to": "B",
       "name": "contains",
-      "hidden": true
-    },
-    {
-      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
-      "to": "House",
-      "name": "contains",
-      "hidden": true
-    },
-    {
-      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
-      "to": "Commune",
-      "name": "contains",
-      "hidden": true
-    },
-    {
-      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
-      "to": "Window",
-      "name": "contains",
-      "hidden": true
-    },
-    {
-      "from": "test/fixtures/class-relationships-crowfeet/in.plantuml",
-      "to": "Door",
-      "name": "contains",
-      "hidden": true
-    },
-    {
-      "from": "Apartment",
-      "to": "Dwelling",
-      "name": "extends",
-      "hidden": true
-    },
-    {
-      "from": "Commune",
-      "to": "Dwelling",
-      "name": "extends",
-      "hidden": true
-    },
-    {
-      "from": "House",
-      "to": "Dwelling",
-      "name": "extends",
       "hidden": true
     }
   ]


### PR DESCRIPTION
For relationships, the parser understands "left crowfoot" notation (`}--`), but not right crowfoot (`--{`). 
This pull request fixes this, including a test fixture for this case.

Note: `--{` is, strictly speaking, not documented on plantuml.com, but if you 
check this example (in the editable example on https://plantuml.com), you'll see that it works with the desired result:

```
class Dwelling {
}

class Window
class Door

Window }-- Dwelling: Composition
Dwelling --{ Door: Composition
```
