### PR TITLE
FIX: nix shell nodejs version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ in stdenv.mkDerivation {
   src = null;
 
   buildInputs = [
-    nodejs
+    nodejs-16_x
   ];
 
   shellHook = ''


### PR DESCRIPTION
Build toolchain now only support nodejs 16.x